### PR TITLE
Remove duplicate entry src/main.cpp

### DIFF
--- a/Sync-my-L2P.pro
+++ b/Sync-my-L2P.pro
@@ -16,7 +16,6 @@ SOURCES += \
     src/logger.cpp \
     src/login.cpp \
     src/logindialog.cpp \
-    src/main.cpp \
     src/message.cpp \
     src/mymainwindow.cpp \
     src/mysortfilterproxymodel.cpp \


### PR DESCRIPTION
Hi, I tried to build new packages for Linux for Sync-my-L2P, because those AppImages are not the common standard for linux builds. But I got the error message:
`main.cpp:(.text.startup+0x0): multiple definition of main`

To fix it, I simply removed the duplicate entry src/main.cpp