### PR TITLE
Project File: Fix path seperator

### DIFF
--- a/Sync-my-L2P.pro
+++ b/Sync-my-L2P.pro
@@ -62,8 +62,8 @@ TRANSLATIONS = lang/sync-my-l2p_de.ts \
                lang/sync-my-l2p_sq.ts
 
 RESOURCES += \
-    icons\icons.qrc \
-    lang\translation.qrc
+    icons/icons.qrc \
+    lang/translation.qrc
 
 RC_FILE = icon.rc
 


### PR DESCRIPTION
Since Qt 5.14 backslashes are not permitted.

Building fails with:
```
/usr/bin/qmake -o Makefile ../Sync-my-L2P/Sync-my-L2P.pro
WARNING: Failure to find: icons\icons.qrc
WARNING: Failure to find: lang\translation.qrc
/usr/bin/rcc: File does not exist 'icons/icons.qrc'
/usr/bin/rcc: File does not exist 'lang/translation.qrc'
```

Thanks to RandomUser for [reporting](https://aur.archlinux.org/packages/sync-my-l2p/#comment-725249) this issue in the AUR!